### PR TITLE
Add `requestId` param for refunds

### DIFF
--- a/src/gateways/AfterpayGateway.php
+++ b/src/gateways/AfterpayGateway.php
@@ -319,6 +319,7 @@ class AfterpayGateway extends BaseGateway
                 'currency' => $transaction->paymentCurrency
             ],
             'merchantReference' => $this->getMerchantReference($order),
+            'requestId' => $transaction->hash,
         ];
 
         $endpoint = sprintf(


### PR DESCRIPTION
The docs seem conflicted about if this is optional or not, but our SAT auditor has flagged `refund_request_id is null`.

> Ensure refund calls are idempotent by verifying that the merchant sends through refund_request_id and refund_merchant_reference for each refund transaction.
> A unique request ID, required for safe retries. It is recommended that the merchant generate a UUID for each unique refund.