### PR TITLE
Add before-send events for purchase, complete purchase and refund

### DIFF
--- a/src/events/SendRequestEvent.php
+++ b/src/events/SendRequestEvent.php
@@ -1,0 +1,16 @@
+<?php
+namespace newism\commerce\afterpay\events;
+
+use yii\base\Event;
+
+class SendRequestEvent extends Event
+{
+    // Properties
+    // ==========================================================================
+
+    public $transaction;
+    public $form;
+    public $method;
+    public $endpoint;
+    public $payload;
+}


### PR DESCRIPTION
We have a need to modify the payload sent to Afterpay, due to some unique handling of a particular Commerce shop. In our case, the shipping address for the order is stored on each line item. Afterpay require a shipping address for the order, and have suggested to use the first line items' address. As such, we need a means of modifying the payload sent to Afterpay.

We've added the following events:

```
EVENT_BEFORE_SEND_PURCHASE_REQUEST
EVENT_BEFORE_SEND_COMPLETE_PURCHASE_REQUEST
EVENT_BEFORE_SEND_REFUND_REQUEST
```

For each event, this fires a `SendRequestEvent` event. You can modify the `payload` which includes access to the auth (merchant ID/Keys), headers (user agent string) and the actual JSON data. As a bonus, why not include the method and endpoint just in case someone needs to modify it.

I'll make mention if this was an Omnipay extended gateway, we'd get this [for free](https://github.com/craftcms/commerce-omnipay/blob/main/src/base/Gateway.php#L104)